### PR TITLE
Add ONLYOFFICE document server chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ovpn0
 *.tgz
 .DS_Store
+helm-docs

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ See [Artifact Hub](https://artifacthub.io/packages/search?repo=suda) or [charts]
 
 [All contributions (no matter if small) are always welcome](http://contributionswelcome.org/).
 
+## Acknowledgements
+
+* [`documentserver` chart](charts/documentserver) is based on [ONLYOFFICE chart/documentation](https://github.com/ONLYOFFICE/Kubernetes-Docs)
+
 ## License
 
 [Apache 2.0 License](./LICENSE)

--- a/charts/documentserver/Chart.yaml
+++ b/charts/documentserver/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+name: documentserver
+description: Helm chart for installing ONLYOFFICE Docs in Kubernetes
+
+type: application
+
+version: 7.0.0
+
+appVersion: 7.0.0

--- a/charts/documentserver/Chart.yaml
+++ b/charts/documentserver/Chart.yaml
@@ -1,9 +1,13 @@
-apiVersion: v1
-name: documentserver
-description: Helm chart for installing ONLYOFFICE Docs in Kubernetes
-
-type: application
-
-version: 7.0.0
-
+apiVersion: v2
 appVersion: 7.0.0
+description: Helm chart for installing ONLYOFFICE Docs in Kubernetes
+name: documentserver
+version: 7.0.0
+type: application
+sources:
+  - https://github.com/suda/charts/tree/main/charts/documentserver
+home: https://github.com/suda/charts/tree/main/charts/documentserver
+maintainers:
+  - name: suda
+    email: admin@suda.pl
+    url: https://suda.pl

--- a/charts/documentserver/Chart.yaml
+++ b/charts/documentserver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 7.0.0
 description: Helm chart for installing ONLYOFFICE Docs in Kubernetes
 name: documentserver
-version: 7.0.0
+version: 7.0.1
 type: application
 sources:
   - https://github.com/suda/charts/tree/main/charts/documentserver

--- a/charts/documentserver/README.md
+++ b/charts/documentserver/README.md
@@ -1,0 +1,74 @@
+# documentserver
+
+![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.0.0](https://img.shields.io/badge/AppVersion-7.0.0-informational?style=flat-square)
+
+Helm chart for installing ONLYOFFICE Docs in Kubernetes
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| connections.amqpHost | string | `"rabbitmq"` |  |
+| connections.amqpProto | string | `"amqp"` |  |
+| connections.amqpUser | string | `"user"` |  |
+| connections.dbHost | string | `"postgresql"` |  |
+| connections.dbPort | string | `"5432"` |  |
+| connections.dbUser | string | `"postgres"` |  |
+| connections.redisHost | string | `"redis-master"` |  |
+| converter.containerImage | string | `"onlyoffice/docs-converter-de:7.0.0.132"` |  |
+| converter.replicas | int | `2` |  |
+| converter.resources.limits | object | `{}` |  |
+| converter.resources.requests | object | `{}` |  |
+| docservice.containerImage | string | `"onlyoffice/docs-docservice-de:7.0.0.132"` |  |
+| docservice.livenessProbe.failureThreshold | int | `5` |  |
+| docservice.livenessProbe.httpGet.path | string | `"/index.html"` |  |
+| docservice.livenessProbe.httpGet.port | int | `8000` |  |
+| docservice.livenessProbe.periodSeconds | int | `10` |  |
+| docservice.livenessProbe.successThreshold | int | `1` |  |
+| docservice.livenessProbe.timeoutSeconds | int | `3` |  |
+| docservice.livenessProbeEnabled | bool | `true` |  |
+| docservice.readinessProbe.failureThreshold | int | `2` |  |
+| docservice.readinessProbe.httpGet.path | string | `"/index.html"` |  |
+| docservice.readinessProbe.httpGet.port | int | `8000` |  |
+| docservice.readinessProbe.periodSeconds | int | `10` |  |
+| docservice.readinessProbe.successThreshold | int | `1` |  |
+| docservice.readinessProbe.timeoutSeconds | int | `3` |  |
+| docservice.readinessProbeEnabled | bool | `true` |  |
+| docservice.replicas | int | `2` |  |
+| docservice.resources.limits | object | `{}` |  |
+| docservice.resources.requests | object | `{}` |  |
+| docservice.startupProbe.failureThreshold | int | `30` |  |
+| docservice.startupProbe.httpGet.path | string | `"/index.html"` |  |
+| docservice.startupProbe.httpGet.port | int | `8000` |  |
+| docservice.startupProbe.periodSeconds | int | `10` |  |
+| docservice.startupProbeEnabled | bool | `true` |  |
+| example.containerImage | string | `"onlyoffice/docs-example:7.0.0.132"` |  |
+| example.enabled | bool | `false` |  |
+| grafana_ingress.enabled | bool | `false` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.ssl.enabled | bool | `false` |  |
+| ingress.ssl.host | string | `"example.com"` |  |
+| ingress.ssl.secret | string | `"tls"` |  |
+| jwt.enabled | bool | `true` |  |
+| jwt.secret | string | `"MYSECRET"` |  |
+| metrics.enabled | bool | `false` |  |
+| persistence.size | string | `"8Gi"` |  |
+| persistence.storageClass | string | `"nfs"` |  |
+| product.name | string | `"onlyoffice"` |  |
+| proxy.livenessProbe.failureThreshold | int | `3` |  |
+| proxy.livenessProbe.httpGet.path | string | `"/index.html"` |  |
+| proxy.livenessProbe.httpGet.port | int | `8888` |  |
+| proxy.livenessProbe.periodSeconds | int | `10` |  |
+| proxy.livenessProbe.successThreshold | int | `1` |  |
+| proxy.livenessProbe.timeoutSeconds | int | `3` |  |
+| proxy.livenessProbeEnabled | bool | `true` |  |
+| proxy.proxyContainerImage | string | `"onlyoffice/docs-proxy-de:7.0.0.132"` |  |
+| proxy.resources.limits | object | `{}` |  |
+| proxy.resources.requests | object | `{}` |  |
+| proxy.startupProbe.failureThreshold | int | `30` |  |
+| proxy.startupProbe.httpGet.path | string | `"/index.html"` |  |
+| proxy.startupProbe.httpGet.port | int | `8888` |  |
+| proxy.startupProbe.periodSeconds | int | `10` |  |
+| proxy.startupProbeEnabled | bool | `true` |  |
+| service.port | int | `8888` |  |
+| service.type | string | `"ClusterIP"` |  |

--- a/charts/documentserver/README.md
+++ b/charts/documentserver/README.md
@@ -17,8 +17,7 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | connections.redisHost | string | `"redis-master"` |  |
 | converter.containerImage | string | `"onlyoffice/docs-converter-de:7.0.0.132"` |  |
 | converter.replicas | int | `2` |  |
-| converter.resources.limits | object | `{}` |  |
-| converter.resources.requests | object | `{}` |  |
+| converter.resources | object | `{}` |  |
 | docservice.containerImage | string | `"onlyoffice/docs-docservice-de:7.0.0.132"` |  |
 | docservice.livenessProbe.failureThreshold | int | `5` |  |
 | docservice.livenessProbe.httpGet.path | string | `"/index.html"` |  |
@@ -35,8 +34,7 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | docservice.readinessProbe.timeoutSeconds | int | `3` |  |
 | docservice.readinessProbeEnabled | bool | `true` |  |
 | docservice.replicas | int | `2` |  |
-| docservice.resources.limits | object | `{}` |  |
-| docservice.resources.requests | object | `{}` |  |
+| docservice.resources | object | `{}` |  |
 | docservice.startupProbe.failureThreshold | int | `30` |  |
 | docservice.startupProbe.httpGet.path | string | `"/index.html"` |  |
 | docservice.startupProbe.httpGet.port | int | `8000` |  |
@@ -63,8 +61,7 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | proxy.livenessProbe.timeoutSeconds | int | `3` |  |
 | proxy.livenessProbeEnabled | bool | `true` |  |
 | proxy.proxyContainerImage | string | `"onlyoffice/docs-proxy-de:7.0.0.132"` |  |
-| proxy.resources.limits | object | `{}` |  |
-| proxy.resources.requests | object | `{}` |  |
+| proxy.resources | object | `{}` |  |
 | proxy.startupProbe.failureThreshold | int | `30` |  |
 | proxy.startupProbe.httpGet.path | string | `"/index.html"` |  |
 | proxy.startupProbe.httpGet.port | int | `8888` |  |

--- a/charts/documentserver/README.md
+++ b/charts/documentserver/README.md
@@ -62,6 +62,7 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | jwt.enabled | bool | `true` |  |
 | jwt.secret | string | `"MYSECRET"` |  |
 | metrics.enabled | bool | `false` |  |
+| persistence.enabled | bool | `false` |  |
 | persistence.size | string | `"8Gi"` |  |
 | product.name | string | `"onlyoffice"` |  |
 | proxy.livenessProbe.failureThreshold | int | `3` |  |

--- a/charts/documentserver/README.md
+++ b/charts/documentserver/README.md
@@ -1,6 +1,6 @@
 # documentserver
 
-![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.0.0](https://img.shields.io/badge/AppVersion-7.0.0-informational?style=flat-square)
+![Version: 7.0.1](https://img.shields.io/badge/Version-7.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.0.0](https://img.shields.io/badge/AppVersion-7.0.0-informational?style=flat-square)
 
 Helm chart for installing ONLYOFFICE Docs in Kubernetes
 
@@ -63,7 +63,6 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | jwt.secret | string | `"MYSECRET"` |  |
 | metrics.enabled | bool | `false` |  |
 | persistence.size | string | `"8Gi"` |  |
-| persistence.storageClass | string | `"nfs"` |  |
 | product.name | string | `"onlyoffice"` |  |
 | proxy.livenessProbe.failureThreshold | int | `3` |  |
 | proxy.livenessProbe.httpGet.path | string | `"/index.html"` |  |

--- a/charts/documentserver/README.md
+++ b/charts/documentserver/README.md
@@ -21,14 +21,16 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | connections.amqpHost | string | `"rabbitmq"` |  |
+| connections.amqpPasswordSecret | string | `""` |  |
 | connections.amqpProto | string | `"amqp"` |  |
 | connections.amqpUser | string | `"user"` |  |
 | connections.dbHost | string | `"postgresql"` |  |
+| connections.dbPasswordSecret | string | `""` |  |
 | connections.dbPort | string | `"5432"` |  |
 | connections.dbUser | string | `"postgres"` |  |
 | connections.redisHost | string | `"redis-master"` |  |
 | converter.containerImage | string | `"onlyoffice/docs-converter-de:7.0.0.132"` |  |
-| converter.replicas | int | `2` |  |
+| converter.replicas | int | `1` |  |
 | converter.resources | object | `{}` |  |
 | docservice.containerImage | string | `"onlyoffice/docs-docservice-de:7.0.0.132"` |  |
 | docservice.livenessProbe.failureThreshold | int | `5` |  |
@@ -37,21 +39,21 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | docservice.livenessProbe.periodSeconds | int | `10` |  |
 | docservice.livenessProbe.successThreshold | int | `1` |  |
 | docservice.livenessProbe.timeoutSeconds | int | `3` |  |
-| docservice.livenessProbeEnabled | bool | `true` |  |
+| docservice.livenessProbeEnabled | bool | `false` |  |
 | docservice.readinessProbe.failureThreshold | int | `2` |  |
 | docservice.readinessProbe.httpGet.path | string | `"/index.html"` |  |
 | docservice.readinessProbe.httpGet.port | int | `8000` |  |
 | docservice.readinessProbe.periodSeconds | int | `10` |  |
 | docservice.readinessProbe.successThreshold | int | `1` |  |
 | docservice.readinessProbe.timeoutSeconds | int | `3` |  |
-| docservice.readinessProbeEnabled | bool | `true` |  |
-| docservice.replicas | int | `2` |  |
+| docservice.readinessProbeEnabled | bool | `false` |  |
+| docservice.replicas | int | `1` |  |
 | docservice.resources | object | `{}` |  |
 | docservice.startupProbe.failureThreshold | int | `30` |  |
 | docservice.startupProbe.httpGet.path | string | `"/index.html"` |  |
 | docservice.startupProbe.httpGet.port | int | `8000` |  |
 | docservice.startupProbe.periodSeconds | int | `10` |  |
-| docservice.startupProbeEnabled | bool | `true` |  |
+| docservice.startupProbeEnabled | bool | `false` |  |
 | example.containerImage | string | `"onlyoffice/docs-example:7.0.0.132"` |  |
 | example.enabled | bool | `false` |  |
 | grafana_ingress.enabled | bool | `false` |  |
@@ -64,6 +66,7 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | metrics.enabled | bool | `false` |  |
 | persistence.enabled | bool | `false` |  |
 | persistence.size | string | `"8Gi"` |  |
+| persistence.storageClass | string | `""` |  |
 | product.name | string | `"onlyoffice"` |  |
 | proxy.livenessProbe.failureThreshold | int | `3` |  |
 | proxy.livenessProbe.httpGet.path | string | `"/index.html"` |  |
@@ -71,13 +74,13 @@ Helm chart for installing ONLYOFFICE Docs in Kubernetes
 | proxy.livenessProbe.periodSeconds | int | `10` |  |
 | proxy.livenessProbe.successThreshold | int | `1` |  |
 | proxy.livenessProbe.timeoutSeconds | int | `3` |  |
-| proxy.livenessProbeEnabled | bool | `true` |  |
+| proxy.livenessProbeEnabled | bool | `false` |  |
 | proxy.proxyContainerImage | string | `"onlyoffice/docs-proxy-de:7.0.0.132"` |  |
 | proxy.resources | object | `{}` |  |
 | proxy.startupProbe.failureThreshold | int | `30` |  |
 | proxy.startupProbe.httpGet.path | string | `"/index.html"` |  |
 | proxy.startupProbe.httpGet.port | int | `8888` |  |
 | proxy.startupProbe.periodSeconds | int | `10` |  |
-| proxy.startupProbeEnabled | bool | `true` |  |
+| proxy.startupProbeEnabled | bool | `false` |  |
 | service.port | int | `8888` |  |
 | service.type | string | `"ClusterIP"` |  |

--- a/charts/documentserver/README.md
+++ b/charts/documentserver/README.md
@@ -4,6 +4,18 @@
 
 Helm chart for installing ONLYOFFICE Docs in Kubernetes
 
+**Homepage:** <https://github.com/suda/charts/tree/main/charts/documentserver>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| suda | admin@suda.pl | https://suda.pl |
+
+## Source Code
+
+* <https://github.com/suda/charts/tree/main/charts/documentserver>
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/documentserver/jobs/prepare4shutdown.yaml
+++ b/charts/documentserver/jobs/prepare4shutdown.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prepare4shutdown
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      volumes:
+        - name: ds-files
+          persistentVolumeClaim:
+            claimName: ds-files
+        - name: remove-db-scripts
+          configMap:
+            name: remove-db-scripts
+        - name: init-db-scripts
+          configMap:
+            name: init-db-scripts
+        - name: stop-scripts
+          configMap:
+            name: stop-ds
+            defaultMode: 0755
+      containers:
+        - name: prepare4shutdown
+          image: postgres
+          envFrom:
+          - configMapRef:
+              name: documentserver
+          env:
+          - name: DB_PWD
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: postgresql-password
+          - name: PRODUCT_NAME
+            value: ${PRODUCT_NAME}
+          volumeMounts:
+          - name: ds-files
+            mountPath: /var/lib/${PRODUCT_NAME}/documentserver/App_Data/cache/files
+          - name: remove-db-scripts
+            mountPath: /sql/removetbl.sql
+            subPath: removetbl.sql
+          - name: init-db-scripts
+            mountPath: /sql/createdb.sql
+            subPath: createdb.sql
+          - name: stop-scripts
+            mountPath: /sql/stop.sh
+            subPath: stop.sh
+          command: ["/bin/sh", "-c"]
+          args: ["/sql/stop.sh"]
+      restartPolicy: Never

--- a/charts/documentserver/jobs/prepare4update.yaml
+++ b/charts/documentserver/jobs/prepare4update.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prepare4update
+spec:
+  backoffLimit: 2
+  template:
+    spec:
+      volumes:
+        - name: ds-files
+          persistentVolumeClaim:
+            claimName: ds-files
+        - name: remove-db-scripts
+          configMap:
+            name: remove-db-scripts
+        - name: init-db-scripts
+          configMap:
+            name: init-db-scripts
+        - name: stop-scripts
+          configMap:
+            name: stop-ds
+            defaultMode: 0755
+      containers:
+        - name: prepare4update
+          image: postgres
+          envFrom:
+          - configMapRef:
+              name: documentserver
+          env:
+          - name: DB_PWD
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: postgresql-password
+          - name: PRODUCT_NAME
+            value: ${PRODUCT_NAME}
+          volumeMounts:
+          - name: ds-files
+            mountPath: /var/lib/${PRODUCT_NAME}/documentserver/App_Data/cache/files
+          - name: remove-db-scripts
+            mountPath: /sql/removetbl.sql
+            subPath: removetbl.sql
+          - name: init-db-scripts
+            mountPath: /sql/createdb.sql
+            subPath: createdb.sql
+          - name: stop-scripts
+            mountPath: /sql/stop.sh
+            subPath: stop.sh
+          command: ["/bin/sh", "-c"]
+          args: ["/sql/stop.sh"]
+      restartPolicy: Never

--- a/charts/documentserver/sources/extraScrapeConfigs.yaml
+++ b/charts/documentserver/sources/extraScrapeConfigs.yaml
@@ -1,0 +1,5 @@
+- job_name: 'statsd'
+  scrape_interval: 30s
+  static_configs:
+    - targets:
+      - statsd-exporter-prometheus-statsd-exporter:9102

--- a/charts/documentserver/sources/ingress_values.yaml
+++ b/charts/documentserver/sources/ingress_values.yaml
@@ -1,0 +1,10 @@
+controller:
+  publishService:
+    enabled: true
+  replicaCount: 2
+  metrics:
+    enabled: true
+    service:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '10254'

--- a/charts/documentserver/sources/license/README.md
+++ b/charts/documentserver/sources/license/README.md
@@ -1,0 +1,1 @@
+Сopy the license file here

--- a/charts/documentserver/sources/metrics/documentserver-statsd-exporter.json
+++ b/charts/documentserver/sources/metrics/documentserver-statsd-exporter.json
@@ -1,0 +1,2797 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 8,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 22,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 76,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_expireDoc_connections_edit",
+              "interval": "",
+              "legendFormat": "number of connections for editing",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Edit",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 78,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_expireDoc_connections_view",
+              "interval": "",
+              "legendFormat": "number of connections for viewing",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "View",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 80,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_expireDoc_connections_edit + ds_expireDoc_connections_view",
+              "interval": "",
+              "legendFormat": "sum of connections for editing and viewing",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Sum",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Сonnecting",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 56,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 52,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(ds_coauth_openDocument_open_sum[5m])/rate(ds_coauth_openDocument_open_count[5m])",
+              "interval": "",
+              "legendFormat": "moving average time of opening documents (for 5 minutes)",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 54,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_openDocument_open",
+              "interval": "",
+              "legendFormat": "quantile=\"{{quantile}}\"",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Quantile (0.5, 0.9, 0.99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "cpm"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 2
+          },
+          "hiddenSeries": false,
+          "id": 74,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_openDocument_open_count - ds_coauth_openDocument_open_count offset 1m",
+              "interval": "",
+              "legendFormat": "number of open documents",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "cpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Opening Documents",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 10,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {},
+              "custom": {},
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 8,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(ds_conv_downloadFile_sum[5m])/rate(ds_conv_downloadFile_count[5m])",
+              "interval": "",
+              "legendFormat": "moving average time of downloading documents (for 5 minutes)",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_conv_downloadFile",
+              "interval": "",
+              "legendFormat": "quantile=\"{{quantile}}\"",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Quantile (0.5, 0.9, 0.99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "cpm"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 3
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_conv_downloadFile_count - ds_conv_downloadFile_count offset 1m",
+              "interval": "",
+              "legendFormat": "number of downloaded files",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "cpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Downloading Documents",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 12,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 4
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(ds_conv_allconvert_sum[5m])/rate(ds_conv_allconvert_count[5m])",
+              "interval": "",
+              "legendFormat": "moving average time of converting documents (for 5 minutes)",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 4
+          },
+          "hiddenSeries": false,
+          "id": 18,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_conv_allconvert",
+              "interval": "",
+              "legendFormat": "quantile=\"{{quantile}}\"",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "quantile (0.5, 0.9, 0.99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "cpm"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 4
+          },
+          "hiddenSeries": false,
+          "id": 14,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_conv_allconvert_count - ds_conv_allconvert_count offset 1m",
+              "interval": "",
+              "legendFormat": "number of conversions",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "cpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Converting Documents",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 32,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 5
+          },
+          "hiddenSeries": false,
+          "id": 30,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(ds_conv_spawnSync_sum[5m])/rate(ds_conv_spawnSync_count[5m])",
+              "interval": "",
+              "legendFormat": "moving average time of converting process (for 5 minutes)",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 5
+          },
+          "hiddenSeries": false,
+          "id": 28,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_conv_spawnSync",
+              "interval": "",
+              "legendFormat": "quantile=\"{{quantile}}\"",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Quantile (0.5, 0.9, 0.99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "cpm"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 5
+          },
+          "hiddenSeries": false,
+          "id": 26,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_conv_spawnSync_count - ds_conv_spawnSync_count offset 1m",
+              "interval": "",
+              "legendFormat": "number of conversion process",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "cpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Converting Process",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 48,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 6
+          },
+          "hiddenSeries": false,
+          "id": 44,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(ds_coauth_data_auth_sum[5m])/rate(ds_coauth_data_auth_count[5m])",
+              "interval": "",
+              "legendFormat": "moving average time of completing authorization (for 5 minutes)",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 6
+          },
+          "hiddenSeries": false,
+          "id": 46,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_data_auth",
+              "interval": "",
+              "legendFormat": "quantile=\"{{quantile}}\"",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Quantile (0.5, 0.9, 0.99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "cpm"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 6
+          },
+          "hiddenSeries": false,
+          "id": 42,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_data_auth_count - ds_coauth_data_auth_count offset 1m",
+              "interval": "",
+              "legendFormat": "number of authorizations",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "cpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Authorizations",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 64,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 60,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(ds_coauth_data_getLock_sum[5m])/rate(ds_coauth_data_getLock_count[5m])",
+              "interval": "",
+              "legendFormat": "moving average time of getLock duration (for 5 minutes)",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 62,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_data_getLock",
+              "interval": "",
+              "legendFormat": "quantile=\"{{quantile}}\"",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Quantile (0.5, 0.9, 0.99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "cpm"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 7
+          },
+          "hiddenSeries": false,
+          "id": 58,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_data_getLock_count - ds_coauth_data_getLock_count offset 1m",
+              "interval": "",
+              "legendFormat": "number of getLocks",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "cpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Get Lock",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 40,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 36,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(ds_coauth_data_saveChanges_sum[5m])/rate(ds_coauth_data_saveChanges_count[5m])",
+              "interval": "",
+              "legendFormat": "moving average time of saving changes (for 5 minutes)",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 38,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_data_saveChanges",
+              "interval": "",
+              "legendFormat": "quantile=\"{{quantile}}\"",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Quantile (0.5, 0.9, 0.99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "cpm"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 34,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_data_saveChanges_count - ds_coauth_data_saveChanges_count offset 1m",
+              "interval": "",
+              "legendFormat": "number of saved changes ",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "cpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Saving Changes",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 72,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 70,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "rate(ds_coauth_openDocument_imgurls_sum[5m])/rate(ds_coauth_openDocument_imgurls_count[5m])",
+              "interval": "",
+              "legendFormat": "moving average time to opening documents with uploading images (for 5 minutes)",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Average time",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 68,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_openDocument_imgurls",
+              "interval": "",
+              "legendFormat": "quantile=\"{{quantile}}\"",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Quantile (0.5, 0.9, 0.99)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {},
+              "unit": "cpm"
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 9
+          },
+          "hiddenSeries": false,
+          "id": 66,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.4.3",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "ds_coauth_openDocument_imgurls_count - ds_coauth_openDocument_imgurls_count offset 1m",
+              "interval": "",
+              "legendFormat": "the number of opened documents with the uploaded images",
+              "queryType": "randomWalk",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Count",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "cpm",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Uploading Images",
+      "type": "row"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Statsd DS",
+  "uid": "LDjoK2UGz",
+  "version": 24
+}

--- a/charts/documentserver/sources/metrics/get_dashboard.sh
+++ b/charts/documentserver/sources/metrics/get_dashboard.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+wget https://grafana.com/api/dashboards/1860/revisions/22/download -O dashboard-node-exporter.json
+wget https://grafana.com/api/dashboards/8588/revisions/1/download -O dashboard-deployment.json
+wget https://grafana.com/api/dashboards/11835/revisions/1/download -O dashboard-redis.json
+wget https://grafana.com/api/dashboards/10991/revisions/8/download -O dashboard-rabbitmq.json
+wget https://grafana.com/api/dashboards/9628/revisions/6/download -O dashboard-postgresql.json
+wget https://grafana.com/api/dashboards/9614/revisions/1/download -O dashboard-nginx-ingress.json
+sed -i 's/${DS_PROMETHEUS}/Prometheus/' *.json
+kubectl create configmap dashboard-node-exporter --from-file=./dashboard-node-exporter.json
+kubectl create configmap dashboard-deployment --from-file=./dashboard-deployment.json
+kubectl create configmap dashboard-redis --from-file=./dashboard-redis.json
+kubectl create configmap dashboard-rabbitmq --from-file=./dashboard-rabbitmq.json
+kubectl create configmap dashboard-postgresql --from-file=./dashboard-postgresql.json
+kubectl create configmap dashboard-nginx-ingress --from-file=./dashboard-nginx-ingress.json
+kubectl create configmap dashboard-documentserver --from-file=./sources/metrics/documentserver-statsd-exporter.json
+helm upgrade prometheus prometheus-community/prometheus \
+--set-file extraScrapeConfigs=./sources/extraScrapeConfigs.yaml

--- a/charts/documentserver/sources/scc/docs-components.yaml
+++ b/charts/documentserver/sources/scc/docs-components.yaml
@@ -1,0 +1,20 @@
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: scc-docs-components
+allowPrivilegedContainer: false
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMax: 101 
+  uidRangeMin: 101
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+  ranges: 
+  - max: 101
+    min: 101
+supplementalGroups:
+  type: MustRunAs
+users: []
+groups: []

--- a/charts/documentserver/sources/scc/helm-components.yaml
+++ b/charts/documentserver/sources/scc/helm-components.yaml
@@ -1,0 +1,20 @@
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: scc-helm-components
+allowPrivilegedContainer: false
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMax: 1001 
+  uidRangeMin: 1001
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+  ranges: 
+  - max: 1001
+    min: 1001
+supplementalGroups:
+  type: MustRunAs
+users: []
+groups: []

--- a/charts/documentserver/sources/scripts/get_logs.sh
+++ b/charts/documentserver/sources/scripts/get_logs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+for i in `kubectl get pod | grep -i converter | awk '{print $1}'`; do
+  kubectl logs $i > $i.txt
+done
+
+for i in `kubectl get pod | grep -i docservice | awk '{print $1}'`; do
+  kubectl logs $i -c proxy > $i-PROXY.txt
+  kubectl logs $i -c docservice > $i-DOCSERVICE.txt
+done

--- a/charts/documentserver/sources/scripts/shutdown-ds.sh
+++ b/charts/documentserver/sources/scripts/shutdown-ds.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+PRODUCT_NAME="onlyoffice"
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -pn | --product_name )
+       if [ "$2" != "" ]; then
+         PRODUCT_NAME=$2
+         shift
+       fi
+    ;;
+  esac
+  shift
+done
+
+init_prepare4shutdown_job(){
+  kubectl get job | grep -iq prepare4shutdown
+  if [ $? -eq 0 ]; then
+    echo A Job named prepare4shutdown exists. Exit
+    exit 1
+  else
+    kubectl delete cm remove-db-scripts init-db-scripts
+    wget -O removetbl.sql https://raw.githubusercontent.com/ONLYOFFICE/server/master/schema/postgresql/removetbl.sql
+    wget -O createdb.sql https://raw.githubusercontent.com/ONLYOFFICE/server/master/schema/postgresql/createdb.sql
+    kubectl create configmap remove-db-scripts --from-file=./removetbl.sql
+    kubectl create configmap init-db-scripts --from-file=./createdb.sql
+    kubectl apply -f ./sources/stop-ds.yaml
+  fi
+}
+
+create_prepare4shutdown_job(){
+  export PRODUCT_NAME="${PRODUCT_NAME}"
+  envsubst < ./jobs/prepare4shutdown.yaml | kubectl apply -f -
+  sleep 5
+  PODNAME="$(kubectl get pod | grep -i prepare4shutdown | awk '{print $1}')"
+}
+
+check_prepare4shutdown_pod_status(){
+  while true; do
+      STATUS="$(kubectl get pod "${PODNAME}" |  awk '{print $3}' | sed -n '$p')"
+      case $STATUS in
+          Error)
+            echo "error"
+            break
+          ;;
+
+          Completed)
+            echo "completed"
+            break
+          ;;
+
+          *)
+            sleep 5
+          ;;
+      esac
+  done
+}
+
+delete_prepare4shutdown_job(){
+  echo -e "\e[0;32m Status of the prepare4shutdown POD: $POD_STATUS. The Job will be deleted \e[0m"
+  kubectl delete job prepare4shutdown
+}
+
+print_error_message(){
+  echo -e "\e[0;31m Status of the prepare4shutdown POD: $POD_STATUS \e[0m"
+  echo -e "\e[0;31m The Job will not be deleted automatically. Further actions to manage the Job must be performed manually. \e[0m"
+}
+
+init_prepare4shutdown_job
+create_prepare4shutdown_job
+
+echo "Getting the prepare4shutdown POD status..."
+POD_STATUS=$(check_prepare4shutdown_pod_status)
+if [[ "$POD_STATUS" == "error" ]]; then
+  print_error_message
+else
+  delete_prepare4shutdown_job
+  echo -e "\e[0;32m The Job shutdown was completed successfully.\e[0m"
+fi
+exit

--- a/charts/documentserver/sources/scripts/update-ds.sh
+++ b/charts/documentserver/sources/scripts/update-ds.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+DOCUMENTSERVER_VERSION=""
+PRODUCT_NAME="onlyoffice"
+PRODUCT_EDITION="de"
+
+if [ "$1" == "" ]; then
+  echo "Basic parameters are missing."
+  exit 1
+fi
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -pn | --product_name )
+       if [ "$2" != "" ]; then
+         PRODUCT_NAME=$2
+         shift
+       fi
+    ;;
+    -pe | --product_edition )
+       if [ "$2" != "" ]; then
+         PRODUCT_EDITION=$2
+         shift
+       fi
+    ;;
+    -dv | --documentserver_version )
+       if [ "$2" != "" ]; then
+         DOCUMENTSERVER_VERSION=$2
+         shift
+       fi
+    ;;
+  esac
+  shift
+done
+
+if [ "$DOCUMENTSERVER_VERSION" == "" ]; then
+  echo -e "\e[0;31m The DOCUMENT SERVER version cannot be empty \e[0m"
+  exit 1
+fi
+
+init_prepare4update_job(){
+  kubectl get job | grep -iq prepare4update
+  if [ $? -eq 0 ]; then
+    echo A Job named prepare4update exists. Exit
+    exit 1
+  else
+    kubectl delete cm remove-db-scripts init-db-scripts
+    wget -O removetbl.sql https://raw.githubusercontent.com/ONLYOFFICE/server/master/schema/postgresql/removetbl.sql
+    wget -O createdb.sql https://raw.githubusercontent.com/ONLYOFFICE/server/master/schema/postgresql/createdb.sql
+    kubectl create configmap remove-db-scripts --from-file=./removetbl.sql
+    kubectl create configmap init-db-scripts --from-file=./createdb.sql
+    kubectl apply -f ./sources/stop-ds.yaml
+  fi
+}
+
+create_prepare4update_job(){
+  export PRODUCT_NAME="${PRODUCT_NAME}"
+  envsubst < ./jobs/prepare4update.yaml | kubectl apply -f -
+  sleep 5
+  PODNAME="$(kubectl get pod | grep -i prepare4update | awk '{print $1}')"
+}
+
+check_prepare4update_pod_status(){
+  while true; do
+      STATUS="$(kubectl get pod "${PODNAME}" |  awk '{print $3}' | sed -n '$p')"
+      case $STATUS in
+          Error)
+            echo "error"
+            break
+          ;;
+
+          Completed)
+            echo "completed"
+            break
+          ;;
+
+          *)
+            sleep 5
+          ;;
+      esac
+  done
+}
+
+delete_prepare4update_job(){
+  echo -e "\e[0;32m Status of the prepare4update POD: $POD_STATUS. The Job will be deleted \e[0m"
+  kubectl delete job prepare4update
+}
+
+update_images(){
+  PRODUCT_NAME=$(echo "${PRODUCT_NAME}" | sed 's/-//g')
+  kubectl set image deployment/converter \
+    converter=${PRODUCT_NAME}/docs-converter-${PRODUCT_EDITION}:${DOCUMENTSERVER_VERSION}
+  kubectl set image deployment/docservice \
+    docservice=${PRODUCT_NAME}/docs-docservice-${PRODUCT_EDITION}:${DOCUMENTSERVER_VERSION} \
+    proxy=${PRODUCT_NAME}/docs-proxy-${PRODUCT_EDITION}:${DOCUMENTSERVER_VERSION}
+}
+
+print_error_message(){
+  echo -e "\e[0;31m Status of the prepare4update POD: $POD_STATUS \e[0m"
+  echo -e "\e[0;31m The Job will not be deleted automatically. Further actions to manage the Job must be performed manually. \e[0m"
+}
+
+init_prepare4update_job
+create_prepare4update_job
+
+echo "Getting the prepare4update POD status..."
+POD_STATUS=$(check_prepare4update_pod_status)
+if [[ "$POD_STATUS" == "error" ]]; then
+  print_error_message
+else
+  delete_prepare4update_job
+  update_images
+  echo -e "\e[0;32m The Job update was completed successfully. Wait until all containers with the new version of the images have the READY status. \e[0m"
+fi
+exit

--- a/charts/documentserver/sources/stop-ds.yaml
+++ b/charts/documentserver/sources/stop-ds.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stop-ds
+data:
+  stop.sh: |-
+    #!/bin/bash
+    apt update
+    apt -y install curl bash
+    curlout="$(curl -v http://docservice:8000/internal/cluster/inactive -X PUT -s)"
+    if [[ "${curlout}" != "true" ]]; then
+      echo -e "\e[0;31m The server could not be disabled \e[0m"
+      exit 1
+    else
+      PGPASSWORD=$DB_PWD psql --host=postgresql --user=postgres -c "\dt" > /dev/null
+      if [ $? -ne 0 ]; then
+        echo -e "\e[0;31m DB is not available \e[0m"
+        exit 1
+      fi
+      FILES_DIR=/var/lib/$PRODUCT_NAME/documentserver/App_Data/cache/files/
+      ls $FILES_DIR > /dev/null
+      if [ $? -ne 0 ]; then
+        echo -e "\e[0;31m Error accessing the $FILES_DIR directory \e[0m"
+        exit 1
+      fi
+      for ENTRY in `ls $FILES_DIR`; do
+        case $ENTRY in
+          errors)
+            ;;
+          forgotten)
+            ;;
+          *)
+            rm -rfv $FILES_DIR$ENTRY
+            ;;
+        esac
+      done
+      PGPASSWORD=$DB_PWD psql --host=postgresql --user=postgres --file=/sql/removetbl.sql
+      PGPASSWORD=$DB_PWD psql --host=postgresql --user=postgres --file=/sql/createdb.sql
+      echo work done
+    fi

--- a/charts/documentserver/templates/configmaps/documentserver.yaml
+++ b/charts/documentserver/templates/configmaps/documentserver.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: documentserver
+data:
+  DB_USER: {{ .Values.connections.dbUser }}
+  DB_HOST: {{ .Values.connections.dbHost }}
+  DB_PORT: {{ .Values.connections.dbPort | quote}}
+  REDIST_SERVER_HOST: {{ .Values.connections.redisHost }}
+  AMQP_HOST: {{ .Values.connections.amqpHost }}
+  AMQP_USER: {{ .Values.connections.amqpUser }}
+  AMQP_PROTO: {{ .Values.connections.amqpProto }}
+  METRICS_HOST: statsd-exporter-prometheus-statsd-exporter
+  METRICS_ENABLED: {{ .Values.metrics.enabled | quote}}
+  {{ if .Values.example.enabled }}
+  EXAMPLE_HOST_PORT: example:3000
+  {{ end }}

--- a/charts/documentserver/templates/configmaps/example.yaml
+++ b/charts/documentserver/templates/configmaps/example.yaml
@@ -1,0 +1,8 @@
+{{ if .Values.example.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example
+data:
+  DS_URL: /
+{{ end }}

--- a/charts/documentserver/templates/configmaps/grafana.yaml
+++ b/charts/documentserver/templates/configmaps/grafana.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.metrics.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-ini
+data:
+  grafana.ini: |-
+    [server]
+    root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+    serve_from_sub_path = true
+{{- end }}

--- a/charts/documentserver/templates/deployments/converter.yaml
+++ b/charts/documentserver/templates/deployments/converter.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: converter
+  labels:
+    app: converter
+spec:
+  replicas: {{ .Values.converter.replicas }}
+  selector:
+    matchLabels:
+      app: converter
+  template:
+    metadata:
+      labels:
+        app: converter
+    spec:
+#      securityContext:
+#        runAsUser: 101
+#        runAsGroup: 101
+      volumes:
+        - name: ds-files
+          persistentVolumeClaim:
+            claimName: ds-files
+        - name: ds-license
+          secret:
+            secretName: license
+      containers:
+        - name: converter
+          image: {{ .Values.converter.containerImage }}
+          resources: {{- toYaml .Values.converter.resources | nindent 12 }}
+          env:
+          - name: DB_PWD
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: postgresql-password
+          - name: AMQP_PWD
+            valueFrom:
+              secretKeyRef:
+                name: rabbitmq
+                key: rabbitmq-password
+          envFrom:
+          - secretRef:
+              name: jwt
+          - configMapRef:
+              name: documentserver
+          volumeMounts:
+          - name: ds-files
+            mountPath: /var/lib/{{ .Values.product.name }}/documentserver/App_Data/cache/files
+          - name: ds-license
+            mountPath: /var/www/{{ .Values.product.name }}/Data
+            readOnly: true

--- a/charts/documentserver/templates/deployments/converter.yaml
+++ b/charts/documentserver/templates/deployments/converter.yaml
@@ -14,13 +14,12 @@ spec:
       labels:
         app: converter
     spec:
-#      securityContext:
-#        runAsUser: 101
-#        runAsGroup: 101
       volumes:
+        {{- if .Values.persistence.enabled }}
         - name: ds-files
           persistentVolumeClaim:
             claimName: ds-files
+        {{- end }}
         - name: ds-license
           secret:
             secretName: license
@@ -45,8 +44,10 @@ spec:
           - configMapRef:
               name: documentserver
           volumeMounts:
+          {{- if .Values.persistence.enabled }}
           - name: ds-files
             mountPath: /var/lib/{{ .Values.product.name }}/documentserver/App_Data/cache/files
+          {{- end }}
           - name: ds-license
             mountPath: /var/www/{{ .Values.product.name }}/Data
             readOnly: true

--- a/charts/documentserver/templates/deployments/converter.yaml
+++ b/charts/documentserver/templates/deployments/converter.yaml
@@ -28,16 +28,20 @@ spec:
           image: {{ .Values.converter.containerImage }}
           resources: {{- toYaml .Values.converter.resources | nindent 12 }}
           env:
+          {{- if .Values.connections.dbPasswordSecret }}
           - name: DB_PWD
             valueFrom:
               secretKeyRef:
                 name: postgresql
                 key: postgresql-password
+          {{- end }}
+          {{- if .Values.connections.amqpPasswordSecret }}
           - name: AMQP_PWD
             valueFrom:
               secretKeyRef:
                 name: rabbitmq
                 key: rabbitmq-password
+          {{- end }}
           envFrom:
           - secretRef:
               name: jwt

--- a/charts/documentserver/templates/deployments/docservice.yaml
+++ b/charts/documentserver/templates/deployments/docservice.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docservice
+  labels:
+    app: docservice
+spec:
+  replicas: {{ .Values.docservice.replicas }}
+  selector:
+    matchLabels:
+      app: docservice
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: docservice
+    spec:
+#      securityContext:
+#        runAsUser: 101
+#        runAsGroup: 101
+      # topologySpreadConstraints:
+      # - maxSkew: 1
+        # topologyKey: doks.digitalocean.com/node-pool
+        # whenUnsatisfiable: DoNotSchedule
+        # labelSelector:
+          # matchLabels:
+            # app: docservice
+      volumes:
+        - name: ds-files
+          persistentVolumeClaim:
+            claimName: ds-files
+        - name: ds-license
+          secret:
+            secretName: license
+      containers:
+        - name: proxy
+          image: {{ .Values.proxy.proxyContainerImage }}
+          ports:
+            - containerPort: 8888
+          {{ if .Values.proxy.livenessProbeEnabled }}
+          livenessProbe: {{ toYaml .Values.proxy.livenessProbe | nindent 14 }}
+          {{ end }}
+          {{ if .Values.proxy.startupProbeEnabled }}
+          startupProbe: {{ toYaml .Values.proxy.startupProbe | nindent 14 }}
+          {{ end }}
+          resources: {{ toYaml .Values.proxy.resources | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: documentserver
+          volumeMounts:
+          - name: ds-files
+            mountPath: /var/lib/{{ .Values.product.name }}/documentserver/App_Data/cache/files
+
+        - name: docservice
+          image: {{ .Values.docservice.containerImage }}
+          ports:
+            - containerPort: 8000
+          {{ if .Values.docservice.readinessProbeEnabled }}
+          readinessProbe: {{ toYaml .Values.docservice.readinessProbe | nindent 14 }}
+          {{ end }}
+          {{ if .Values.docservice.livenessProbeEnabled }}
+          livenessProbe: {{ toYaml .Values.docservice.livenessProbe | nindent 14 }}
+          {{ end }}
+          {{ if .Values.docservice.startupProbeEnabled }}
+          startupProbe: {{ toYaml .Values.docservice.startupProbe | nindent 14 }}
+          {{ end }}
+          resources: {{ toYaml .Values.docservice.resources | nindent 12 }}
+          env:
+          - name: DB_PWD
+            valueFrom:
+              secretKeyRef:
+                name: postgresql
+                key: postgresql-password
+          - name: AMQP_PWD
+            valueFrom:
+              secretKeyRef:
+                name: rabbitmq
+                key: rabbitmq-password
+          envFrom:
+          - secretRef:
+              name: jwt
+          - configMapRef:
+              name: documentserver
+          volumeMounts:
+          - name: ds-files
+            mountPath: /var/lib/{{ .Values.product.name }}/documentserver/App_Data/cache/files
+          - name: ds-license
+            mountPath: /var/www/{{ .Values.product.name }}/Data
+            readOnly: true

--- a/charts/documentserver/templates/deployments/docservice.yaml
+++ b/charts/documentserver/templates/deployments/docservice.yaml
@@ -61,16 +61,20 @@ spec:
           {{ end }}
           resources: {{ toYaml .Values.docservice.resources | nindent 12 }}
           env:
+          {{- if .Values.connections.dbPasswordSecret }}
           - name: DB_PWD
             valueFrom:
               secretKeyRef:
                 name: postgresql
                 key: postgresql-password
+          {{- end }}
+          {{- if .Values.connections.amqpPasswordSecret }}
           - name: AMQP_PWD
             valueFrom:
               secretKeyRef:
                 name: rabbitmq
                 key: rabbitmq-password
+          {{- end }}
           envFrom:
           - secretRef:
               name: jwt

--- a/charts/documentserver/templates/deployments/docservice.yaml
+++ b/charts/documentserver/templates/deployments/docservice.yaml
@@ -16,16 +16,6 @@ spec:
       labels:
         app: docservice
     spec:
-#      securityContext:
-#        runAsUser: 101
-#        runAsGroup: 101
-      # topologySpreadConstraints:
-      # - maxSkew: 1
-        # topologyKey: doks.digitalocean.com/node-pool
-        # whenUnsatisfiable: DoNotSchedule
-        # labelSelector:
-          # matchLabels:
-            # app: docservice
       volumes:
         - name: ds-files
           persistentVolumeClaim:

--- a/charts/documentserver/templates/deployments/docservice.yaml
+++ b/charts/documentserver/templates/deployments/docservice.yaml
@@ -17,9 +17,11 @@ spec:
         app: docservice
     spec:
       volumes:
+        {{- if .Values.persistence.enabled }}
         - name: ds-files
           persistentVolumeClaim:
             claimName: ds-files
+        {{- end }}
         - name: ds-license
           secret:
             secretName: license
@@ -38,9 +40,11 @@ spec:
           envFrom:
           - configMapRef:
               name: documentserver
+          {{- if .Values.persistence.enabled }}
           volumeMounts:
           - name: ds-files
             mountPath: /var/lib/{{ .Values.product.name }}/documentserver/App_Data/cache/files
+          {{- end }}
 
         - name: docservice
           image: {{ .Values.docservice.containerImage }}
@@ -73,8 +77,10 @@ spec:
           - configMapRef:
               name: documentserver
           volumeMounts:
+          {{- if .Values.persistence.enabled }}
           - name: ds-files
             mountPath: /var/lib/{{ .Values.product.name }}/documentserver/App_Data/cache/files
+          {{- end }}
           - name: ds-license
             mountPath: /var/www/{{ .Values.product.name }}/Data
             readOnly: true

--- a/charts/documentserver/templates/ingresses/documentserver.yaml
+++ b/charts/documentserver/templates/ingresses/documentserver.yaml
@@ -1,0 +1,31 @@
+{{ if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: documentserver
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+spec:
+  {{ if .Values.ingress.ssl.enabled }}
+  tls: 
+  - hosts:
+    - {{ .Values.ingress.ssl.host }}
+    secretName: {{ .Values.ingress.ssl.secret }}
+  {{ end }}
+  rules:
+  {{ if .Values.ingress.ssl.enabled }}
+  - host: {{ .Values.ingress.ssl.host }}
+  {{ else }}
+  - host:
+  {{ end }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: documentserver
+            port:
+              number: 8888
+{{ end }}

--- a/charts/documentserver/templates/ingresses/grafana.yaml
+++ b/charts/documentserver/templates/ingresses/grafana.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.grafana_ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-body-size: 100m
+spec:
+  {{ if .Values.ingress.ssl.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.ssl.host }}
+    secretName: {{ .Values.ingress.ssl.secret }}
+  {{ end }}
+  rules:
+  {{ if .Values.ingress.ssl.enabled }}
+  - host: {{ .Values.ingress.ssl.host }}
+  {{ else }}
+  - host:
+  {{ end }}
+    http:
+      paths:
+      - path: /grafana/
+        pathType: Prefix
+        backend:
+          service:
+            name: grafana
+            port:
+              number: 80
+{{- end }}

--- a/charts/documentserver/templates/pods/example.yaml
+++ b/charts/documentserver/templates/pods/example.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.example.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+  labels:
+    app: example
+spec:
+#  securityContext:
+#    runAsUser: 1001
+#    runAsGroup: 1001
+  containers:
+    - name: example
+      image: {{ .Values.example.containerImage | quote }}
+      ports:
+        - containerPort: 3000
+      envFrom:
+        - secretRef:
+            name: jwt
+        - configMapRef:
+              name: example
+{{ end }}

--- a/charts/documentserver/templates/pvc/ds-files.yaml
+++ b/charts/documentserver/templates/pvc/ds-files.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ds-files
+spec:
+  storageClassName: {{ .Values.persistence.storageClass }}
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}

--- a/charts/documentserver/templates/pvc/ds-files.yaml
+++ b/charts/documentserver/templates/pvc/ds-files.yaml
@@ -3,8 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: ds-files
 spec:
-  {{- if Values.persistence.storageClass }}
-  storageClassName: {{ if (eq "-" Values.persistence.storageClass) }}""{{- else }}{{ Values.persistence.storageClass | quote }}{{- end }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ if (eq "-" .Values.persistence.storageClass) }}""{{- else }}{{ .Values.persistence.storageClass | quote }}{{- end }}
   {{- end }}
   accessModes:
     - ReadWriteMany

--- a/charts/documentserver/templates/pvc/ds-files.yaml
+++ b/charts/documentserver/templates/pvc/ds-files.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/documentserver/templates/pvc/ds-files.yaml
+++ b/charts/documentserver/templates/pvc/ds-files.yaml
@@ -3,7 +3,9 @@ kind: PersistentVolumeClaim
 metadata:
   name: ds-files
 spec:
-  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- if Values.persistence.storageClass }}
+  storageClassName: {{ if (eq "-" Values.persistence.storageClass) }}""{{- else }}{{ Values.persistence.storageClass | quote }}{{- end }}
+  {{- end }}
   accessModes:
     - ReadWriteMany
   volumeMode: Filesystem

--- a/charts/documentserver/templates/secrets/grafana-datasource.yaml
+++ b/charts/documentserver/templates/secrets/grafana-datasource.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.metrics.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-datasource
+type: Opaque
+stringData:
+  prometheus.yaml: |    
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        url: http://prometheus-server
+        editable: true
+{{- end }}

--- a/charts/documentserver/templates/secrets/jwt.yaml
+++ b/charts/documentserver/templates/secrets/jwt.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jwt
+type: Opaque
+#immutable: true
+stringData:
+  JWT_ENABLED: {{ .Values.jwt.enabled | quote }}
+  {{ if .Values.jwt.enabled }}
+  JWT_SECRET: {{ .Values.jwt.secret | quote }}
+  {{ end }}

--- a/charts/documentserver/templates/secrets/license.yaml
+++ b/charts/documentserver/templates/secrets/license.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: license
+type: Opaque
+data:
+{{ (.Files.Glob "sources/license/license.lic").AsSecrets | indent 2 }}

--- a/charts/documentserver/templates/services/docservice.yaml
+++ b/charts/documentserver/templates/services/docservice.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: docservice
+spec:
+  selector:
+    app: docservice
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8000
+      targetPort: 8000
+  type: ClusterIP

--- a/charts/documentserver/templates/services/documentserver.yaml
+++ b/charts/documentserver/templates/services/documentserver.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: documentserver
+spec:
+  selector:
+    app: docservice
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: 8888
+  type: {{ .Values.service.type }}

--- a/charts/documentserver/templates/services/example.yaml
+++ b/charts/documentserver/templates/services/example.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.example.enabled }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: example
+spec:
+  selector:
+    app: example
+  ports:
+    - name: http
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+  type: ClusterIP
+{{ end }}

--- a/charts/documentserver/values.yaml
+++ b/charts/documentserver/values.yaml
@@ -25,7 +25,7 @@ persistence:
   # Enabling persistence
   enabled: false
   # Storage class name
-  # storageClass: ""
+  storageClass: ""
   # Storage volume size
   size: 8Gi
 
@@ -41,11 +41,11 @@ example:
 
 docservice:
   # docservice replicas quantity
-  replicas: 2
+  replicas: 1
   # docservice container image name
   containerImage: onlyoffice/docs-docservice-de:7.0.0.132
   # Enable readinessProbe for docservice
-  readinessProbeEnabled: true
+  readinessProbeEnabled: false
   readinessProbe:
     failureThreshold: 2
     httpGet:
@@ -55,7 +55,7 @@ docservice:
     successThreshold: 1
     timeoutSeconds: 3
   # Enable livenessProbe for docservice
-  livenessProbeEnabled: true
+  livenessProbeEnabled: false
   livenessProbe:
     failureThreshold: 5
     httpGet:
@@ -65,7 +65,7 @@ docservice:
     successThreshold: 1
     timeoutSeconds: 3
   # Enable startupProbe for docservice
-  startupProbeEnabled: true
+  startupProbeEnabled: false
   startupProbe:
     httpGet:
       path: /index.html
@@ -86,7 +86,7 @@ proxy:
   # docservice proxy container image name
   proxyContainerImage: onlyoffice/docs-proxy-de:7.0.0.132
   # Enable livenessProbe for proxy
-  livenessProbeEnabled: true
+  livenessProbeEnabled: false
   livenessProbe:
     failureThreshold: 3
     httpGet:
@@ -96,7 +96,7 @@ proxy:
     successThreshold: 1
     timeoutSeconds: 3
   # Enable startupProbe for proxy
-  startupProbeEnabled: true
+  startupProbeEnabled: false
   startupProbe:
     httpGet:
       path: /index.html
@@ -115,7 +115,7 @@ proxy:
 
 converter:
   # Converter replicas quantity
-  replicas: 2
+  replicas: 1
   # Converter container image name
   containerImage: onlyoffice/docs-converter-de:7.0.0.132
 

--- a/charts/documentserver/values.yaml
+++ b/charts/documentserver/values.yaml
@@ -8,6 +8,8 @@ connections:
   dbUser: postgres
   # Database server port number
   dbPort: "5432"
+  # Secret name to use for the database password
+  dbPasswordSecret: ""
   # IP address or the name of the redis host
   redisHost: redis-master
   # IP address or the name of the message broker
@@ -16,6 +18,8 @@ connections:
   amqpUser: user
   # Messabe-broker protocol
   amqpProto: amqp
+  # Secret name to use for the database password
+  amqpPasswordSecret: ""
 
 persistence:
   # Enabling persistence

--- a/charts/documentserver/values.yaml
+++ b/charts/documentserver/values.yaml
@@ -18,6 +18,8 @@ connections:
   amqpProto: amqp
 
 persistence:
+  # Enabling persistence
+  enabled: false
   # Storage class name
   # storageClass: ""
   # Storage volume size

--- a/charts/documentserver/values.yaml
+++ b/charts/documentserver/values.yaml
@@ -1,0 +1,121 @@
+product:
+  name: onlyoffice
+
+connections:
+  dbHost: postgresql
+  dbUser: postgres
+  dbPort: "5432"
+  redisHost: redis-master
+  amqpHost: rabbitmq
+  amqpUser: user
+  amqpProto: amqp
+
+persistence:
+  storageClass: "nfs"
+  size: 8Gi
+
+metrics:
+  enabled: false
+
+example:
+  enabled: false
+  containerImage: onlyoffice/docs-example:7.0.0.132
+
+docservice:
+  replicas: 2
+  readinessProbeEnabled: true
+  readinessProbe:
+    failureThreshold: 2
+    httpGet:
+      path: /index.html
+      port: 8000
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 3
+  livenessProbeEnabled: true
+  livenessProbe:
+    failureThreshold: 5
+    httpGet:
+      path: /index.html
+      port: 8000
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 3
+  startupProbeEnabled: true
+  startupProbe:
+    httpGet:
+      path: /index.html
+      port: 8000
+    failureThreshold: 30
+    periodSeconds: 10
+  containerImage: onlyoffice/docs-docservice-de:7.0.0.132
+  resources:
+    ##Example:
+    ##requests:
+    ##  memory: "256Mi"
+    ##  cpu: "100m"
+    requests: {}
+    ##limits:
+    ##  memory: "2Gi"
+    ##  cpu: "1000m"
+    limits: {}
+
+proxy:
+  livenessProbeEnabled: true
+  livenessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /index.html
+      port: 8888
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 3
+  startupProbeEnabled: true
+  startupProbe:
+    httpGet:
+      path: /index.html
+      port: 8888
+    failureThreshold: 30
+    periodSeconds: 10
+  proxyContainerImage: onlyoffice/docs-proxy-de:7.0.0.132
+  resources:
+    ##Example:
+    ##requests:
+    ##  memory: "256Mi"
+    ##  cpu: "100m"
+    requests: {}
+    ##limits:
+    ##  memory: "2Gi"
+    ##  cpu: "1000m"
+    limits: {}
+
+converter:
+  replicas: 2
+  containerImage: onlyoffice/docs-converter-de:7.0.0.132
+  resources:
+    ##Example:
+    ##requests:
+    ##  memory: "256Mi"
+    ##  cpu: "100m"
+    requests: {}
+    ##limits:
+    ##  memory: "2Gi"
+    ##  cpu: "1000m"
+    limits: {}
+
+jwt:
+  enabled: true
+  secret: MYSECRET
+
+service:
+  type: ClusterIP
+  port: 8888
+
+ingress:
+  enabled: false
+  ssl:
+    enabled: false
+    host: example.com
+    secret: tls
+grafana_ingress:
+  enabled: false

--- a/charts/documentserver/values.yaml
+++ b/charts/documentserver/values.yaml
@@ -18,9 +18,9 @@ connections:
   amqpProto: amqp
 
 persistence:
-  # storage class name
-  storageClass: "nfs"
-  # storage volume size
+  # Storage class name
+  # storageClass: ""
+  # Storage volume size
   size: 8Gi
 
 metrics:

--- a/charts/documentserver/values.yaml
+++ b/charts/documentserver/values.yaml
@@ -2,27 +2,43 @@ product:
   name: onlyoffice
 
 connections:
+  # IP address or the name of the database
   dbHost: postgresql
+  # Database user
   dbUser: postgres
+  # Database server port number
   dbPort: "5432"
+  # IP address or the name of the redis host
   redisHost: redis-master
+  # IP address or the name of the message broker
   amqpHost: rabbitmq
+  # Messabe broker user
   amqpUser: user
+  # Messabe-broker protocol
   amqpProto: amqp
 
 persistence:
+  # storage class name
   storageClass: "nfs"
+  # storage volume size
   size: 8Gi
 
 metrics:
+  # Statsd installation
   enabled: false
 
 example:
+  # Choice of example installation
   enabled: false
+  # Example container image name
   containerImage: onlyoffice/docs-example:7.0.0.132
 
 docservice:
+  # docservice replicas quantity
   replicas: 2
+  # docservice container image name
+  containerImage: onlyoffice/docs-docservice-de:7.0.0.132
+  # Enable readinessProbe for docservice
   readinessProbeEnabled: true
   readinessProbe:
     failureThreshold: 2
@@ -32,6 +48,7 @@ docservice:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 3
+  # Enable livenessProbe for docservice
   livenessProbeEnabled: true
   livenessProbe:
     failureThreshold: 5
@@ -41,6 +58,7 @@ docservice:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 3
+  # Enable startupProbe for docservice
   startupProbeEnabled: true
   startupProbe:
     httpGet:
@@ -48,19 +66,20 @@ docservice:
       port: 8000
     failureThreshold: 30
     periodSeconds: 10
-  containerImage: onlyoffice/docs-docservice-de:7.0.0.132
-  resources:
-    ##Example:
-    ##requests:
-    ##  memory: "256Mi"
-    ##  cpu: "100m"
-    requests: {}
-    ##limits:
-    ##  memory: "2Gi"
-    ##  cpu: "1000m"
-    limits: {}
+
+  # CPU/Memory resource requests/limits
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
 
 proxy:
+  # docservice proxy container image name
+  proxyContainerImage: onlyoffice/docs-proxy-de:7.0.0.132
+  # Enable livenessProbe for proxy
   livenessProbeEnabled: true
   livenessProbe:
     failureThreshold: 3
@@ -70,6 +89,7 @@ proxy:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 3
+  # Enable startupProbe for proxy
   startupProbeEnabled: true
   startupProbe:
     httpGet:
@@ -77,45 +97,54 @@ proxy:
       port: 8888
     failureThreshold: 30
     periodSeconds: 10
-  proxyContainerImage: onlyoffice/docs-proxy-de:7.0.0.132
-  resources:
-    ##Example:
-    ##requests:
-    ##  memory: "256Mi"
-    ##  cpu: "100m"
-    requests: {}
-    ##limits:
-    ##  memory: "2Gi"
-    ##  cpu: "1000m"
-    limits: {}
+
+  # CPU/Memory resource requests/limits
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
 
 converter:
+  # Converter replicas quantity
   replicas: 2
+  # Converter container image name
   containerImage: onlyoffice/docs-converter-de:7.0.0.132
-  resources:
-    ##Example:
-    ##requests:
-    ##  memory: "256Mi"
-    ##  cpu: "100m"
-    requests: {}
-    ##limits:
-    ##  memory: "2Gi"
-    ##  cpu: "1000m"
-    limits: {}
+
+  # CPU/Memory resource requests/limits
+  resources: {}
+    # limits:
+    #  cpu: 100m
+    #  memory: 128Mi
+    # requests:
+    #  cpu: 100m
+    #  memory: 128Mi
 
 jwt:
+  # JWT enabling parameter
   enabled: true
+  # JWT secret
   secret: MYSECRET
 
 service:
+  # documentserver service type
   type: ClusterIP
+  # documentserver service port
   port: 8888
 
 ingress:
+  # Installation of ingress service
   enabled: false
   ssl:
+    # Installation SSL for ingress service
     enabled: false
+    # Host for ingress
     host: example.com
+    # Secret name for SSL
     secret: tls
+
 grafana_ingress:
+  # Installation grafana of ingress service
   enabled: false


### PR DESCRIPTION
This PR adds `documentserver` chart, based on [ONLYOFFICE chart/documentation](https://github.com/ONLYOFFICE/Kubernetes-Docs).