### PR TITLE
Customizable secrets and config maps name

### DIFF
--- a/charts/personal-ovpn/Chart.yaml
+++ b/charts/personal-ovpn/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.4"
 description: Roll your own OpenVPN server
 name: personal-ovpn
-version: 0.2.3
+version: 0.2.4
 type: application
 source:
   - https://github.com/suda/charts/tree/main/charts/personal-ovpn

--- a/charts/personal-ovpn/Chart.yaml
+++ b/charts/personal-ovpn/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.4"
 description: Roll your own OpenVPN server
 name: personal-ovpn
-version: 0.2.4
+version: 0.2.5
 type: application
 source:
   - https://github.com/suda/charts/tree/main/charts/personal-ovpn

--- a/charts/personal-ovpn/Chart.yaml
+++ b/charts/personal-ovpn/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.4"
 description: Roll your own OpenVPN server
 name: personal-ovpn
-version: 0.2.2
+version: 0.2.3
 type: application
 source:
   - https://github.com/suda/charts/tree/main/charts/personal-ovpn

--- a/charts/personal-ovpn/Chart.yaml
+++ b/charts/personal-ovpn/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.4"
 description: Roll your own OpenVPN server
 name: personal-ovpn
-version: 0.2.4
+version: 0.2.3
 type: application
 source:
   - https://github.com/suda/charts/tree/main/charts/personal-ovpn

--- a/charts/personal-ovpn/README.md
+++ b/charts/personal-ovpn/README.md
@@ -73,6 +73,7 @@ But if you really want to, you can enable it by setting `limitTraficToNamespace`
 | namespace | object | `{"name":"ovpn"}` | release namespace |
 | nodeSelector | object | `{}` | node labels for pod assignment |
 | resources | object | `{}` | pod resource requests & limits |
+| secretName | string | `"ovpn0"` |  |
 | security.ipForward | int | `0` |  |
 | security.privileged | bool | `false` |  |
 | service.port | int | `31304` | OpenVPN port |

--- a/charts/personal-ovpn/README.md
+++ b/charts/personal-ovpn/README.md
@@ -73,6 +73,8 @@ But if you really want to, you can enable it by setting `limitTraficToNamespace`
 | namespace | object | `{"name":"ovpn"}` | release namespace |
 | nodeSelector | object | `{}` | node labels for pod assignment |
 | resources | object | `{}` | pod resource requests & limits |
+| security.ipForward | int | `0` |  |
+| security.privileged | bool | `false` |  |
 | service.port | int | `31304` | OpenVPN port |
 | service.protocol | string | `"TCP"` | OpenVPN protocol |
 | service.type | string | `"NodePort"` | Service type |

--- a/charts/personal-ovpn/README.md
+++ b/charts/personal-ovpn/README.md
@@ -76,6 +76,7 @@ But if you really want to, you can enable it by setting `limitTraficToNamespace`
 | security.ipForward | int | `0` |  |
 | security.privileged | bool | `false` |  |
 | service.port | int | `31304` | OpenVPN port |
+| service.port | int | `31304` | OpenVPN port |
 | service.protocol | string | `"TCP"` | OpenVPN protocol |
 | service.type | string | `"NodePort"` | Service type |
 | tolerations | list | `[]` | node taints to tolerate (requires Kubernetes >=1.6) |

--- a/charts/personal-ovpn/templates/deployment.yaml
+++ b/charts/personal-ovpn/templates/deployment.yaml
@@ -45,15 +45,15 @@ spec:
             - name: data
               mountPath: {{ .Values.automatic.persistence.mountPath }}
             {{- else }}
-            - name: ovpn0-key
+            - name: {{ .Values.secretName }}-key
               mountPath: /etc/openvpn/pki/private
-            - name: ovpn0-cert
+            - name: {{ .Values.secretName }}-cert
               mountPath: /etc/openvpn/pki/issued
-            - name: ovpn0-pki
+            - name: {{ .Values.secretName }}-pki
               mountPath: /etc/openvpn/pki
-            - name: ovpn0-conf
+            - name: {{ .Values.secretName }}-conf
               mountPath: /etc/openvpn
-            - name: ccd0
+            - name: {{ .Values.secretName }}-ccd0
               mountPath: /etc/openvpn/ccd
             {{- end }}
           resources:
@@ -76,21 +76,21 @@ spec:
           persistentVolumeClaim:
             claimName: {{ if .Values.automatic.persistence.existingClaim }}{{ .Values.automatic.persistence.existingClaim }}{{- else }}{{ include "personal-ovpn.name" . }}{{- end }}
         {{- else }}
-        - name: ovpn0-key
+        - name: {{ .Values.secretName }}-key
           secret:
-            secretName: ovpn0-key
+            secretName: {{ .Values.secretName }}-key
             defaultMode: 0600
-        - name: ovpn0-cert
+        - name: {{ .Values.secretName }}-cert
           secret:
-            secretName: ovpn0-cert
-        - name: ovpn0-pki
+            secretName: {{ .Values.secretName }}-cert
+        - name: {{ .Values.secretName }}-pki
           secret:
-            secretName: ovpn0-pki
+            secretName: {{ .Values.secretName }}-pki
             defaultMode: 0600
-        - name: ovpn0-conf
+        - name: {{ .Values.secretName }}-conf
           configMap:
-            name: ovpn0-conf
-        - name: ccd0
+            name: {{ .Values.secretName }}-conf
+        - name: {{ .Values.secretName }}-ccd0
           configMap:
-            name: ccd0
+            name: {{ .Values.secretName }}-ccd0
         {{- end }}

--- a/charts/personal-ovpn/templates/deployment.yaml
+++ b/charts/personal-ovpn/templates/deployment.yaml
@@ -33,6 +33,13 @@ spec:
             capabilities:
               add:
                 - NET_ADMIN
+            privileged: {{ .Values.security.privileged }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - "sysctl"
+                  - "net.ipv4.ip_forward={{ .Values.security.ipForward }}"
           volumeMounts:
             {{- if .Values.automatic.enabled }}
             - name: data

--- a/charts/personal-ovpn/templates/service.yaml
+++ b/charts/personal-ovpn/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: openvpn
       protocol: {{ .Values.service.protocol }}
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       name: openvpn
   selector:
     app.kubernetes.io/name: {{ include "personal-ovpn.name" . }}

--- a/charts/personal-ovpn/values.yaml
+++ b/charts/personal-ovpn/values.yaml
@@ -56,6 +56,9 @@ tolerations: []
 # affinity -- node/pod affinities (requires Kubernetes >=1.6)
 affinity: {}
 
+# Define configuration and PKI using secrets and configmaps
+secretName: ovpn0
+
 automatic:
   # automatic.enabled -- Skip manual steps and generate configuration & pki according to values config, Warning, PKI will be passwordless !
   enabled: false

--- a/charts/personal-ovpn/values.yaml
+++ b/charts/personal-ovpn/values.yaml
@@ -23,6 +23,10 @@ service:
   # service.type -- Service type
   type: NodePort
 
+# securityContext -- security context for pod
+security:
+  privileged: false
+  ipForward: 0
 # limitTraficToNamespace -- limit network traffic just to OpenVPN namespace
 limitTraficToNamespace: true
 # limitedCidr -- CIDR to be blocked out

--- a/charts/personal-ovpn/values.yaml
+++ b/charts/personal-ovpn/values.yaml
@@ -25,7 +25,6 @@ service:
   # service.nodePort -- port binding for the node
   port: 31304
 
-
 # securityContext -- security context for pod
 security:
   privileged: false

--- a/charts/personal-ovpn/values.yaml
+++ b/charts/personal-ovpn/values.yaml
@@ -22,6 +22,9 @@ service:
   port: 31304
   # service.type -- Service type
   type: NodePort
+  # service.nodePort -- port binding for the node
+  port: 31304
+
 
 # securityContext -- security context for pod
 security:


### PR DESCRIPTION
The idea behind this is to be able to use the same namespace while deploying different VPN services.

***Note:*** To be evaluated after #16 
